### PR TITLE
Seed clustering changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,8 +235,8 @@ DEPS += $(INC_DIR)/progress_bar.hpp
 DEPS += $(INC_DIR)/backward.hpp
 
 ifneq ($(shell uname -s),Darwin)
-    #DEPS += $(LIB_DIR)/libtcmalloc_minimal.a
-    #LD_LIB_FLAGS += -ltcmalloc_minimal
+    DEPS += $(LIB_DIR)/libtcmalloc_minimal.a
+    LD_LIB_FLAGS += -ltcmalloc_minimal
 endif
 
 .PHONY: clean get-deps deps test set-path static docs .pre-build .check-environment .check-git .no-git

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -2208,8 +2208,8 @@ DistanceIndex::ChainIndex::ChainIndex(DistanceIndex* di, vector<int64_t> v) {
     
     distIndex = di;
 
-    size_t numNodes = v.size()-2 / 4;
-  
+    size_t numNodes = (v.size()-3) / 4;
+    
     chainStartID = v[0];
     chainEndID = v[1];
     int64_t par = v[2];
@@ -2243,7 +2243,7 @@ vector<int64_t> DistanceIndex::ChainIndex::toVector() {
     if (loops) { numNodes = numNodes + 1; } 
 
     vector<int64_t> v;
-    v.resize(numNodes * 4 + 2);
+    v.resize(numNodes * 4 + 3);
     v[0] = chainStartID;
     v[1] = chainEndID;
     v[2] =  parent.second ? -(int64_t) parent.first :

--- a/src/seed_clusterer.cpp
+++ b/src/seed_clusterer.cpp
@@ -1,7 +1,5 @@
 #include "seed_clusterer.hpp"
 
-#define DEBUG 
-
 namespace vg {
     //TODO: Put this somewhere else???
     SnarlSeedClusterer::SnarlSeedClusterer() {
@@ -429,11 +427,13 @@ for (cluster_t c : clusters) {
                             }
                         }
                     }
+#ifdef DEBUG
 cerr << "cluster is assigned to the following chain clusters: " << endl;
 for (size_t a : curr_cluster_assignments) {
 cerr << a << " " ;
 }
 cerr << endl;
+#endif
                     vector<pair<hash_set<size_t>, hash_set<size_t>>> 
                                                               new_chain_indices;
                     pair<hash_set<size_t>, hash_set<size_t>> new_chain_cluster;

--- a/src/snarls.cpp
+++ b/src/snarls.cpp
@@ -611,6 +611,16 @@ bool SnarlManager::chain_orientation_of(const Snarl* snarl) const {
     return false;
 }
 
+size_t SnarlManager::chain_rank_of(const Snarl* snarl) const { 
+    const Chain* chain = chain_of(snarl);
+    if (chain != nullptr) {
+        // The index is a perfectly good rank.
+        return record(snarl)->parent_chain_index;
+    }
+    // If you're in a single-snarl chain you are at index 0.
+    return 0;
+}
+
 bool SnarlManager::in_nontrivial_chain(const Snarl* here) const {
     return chain_of(here)->size() > 1;
 }

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -395,6 +395,9 @@ public:
         
     /// Construct a SnarlManager for the snarls contained in an input stream
     SnarlManager(istream& in);
+    
+    /// Construct a SnarlManager from a function that calls a callback with each Snarl in turn
+    SnarlManager(const function<void(const function<void(Snarl&)>&)>& for_each_snarl);
         
     /// Default constructor for an empty SnarlManager. Must call finish() once
     /// all snarls have been added with add_snarl().

--- a/src/snarls.hpp
+++ b/src/snarls.hpp
@@ -178,12 +178,14 @@ ChainIterator chain_rend(const Chain& chain);
 ChainIterator chain_rcbegin(const Chain& chain);
 ChainIterator chain_rcend(const Chain& chain);
     
-/// We also define a function for getting the ChainIterator (forward or
-/// reverse complement) for a chain starting with a given snarl in the given
-/// inward orientation
+/// We also define a function for getting the ChainIterator (forward or reverse
+/// complement) for a chain starting with a given snarl in the given inward
+/// orientation. Only works for bounding snarls of the chain.
 ChainIterator chain_begin_from(const Chain& chain, const Snarl* start_snarl, bool snarl_orientation);
-/// And the end iterator for the chain (forward or reverse complement)
-/// viewed from a given snarl in the given inward orientation
+/// And the end iterator for the chain (forward or reverse complement) viewed
+/// from a given snarl in the given inward orientation. Only works for bounding
+/// snarls of the chain, and should be the *same* bounding snarl as was used
+/// for chain_begin_from.
 ChainIterator chain_end_from(const Chain& chain, const Snarl* start_snarl, bool snarl_orientation);
     
 /**
@@ -467,7 +469,17 @@ public:
     /// If the given Snarl is backward in its chain, return true. Otherwise,
     /// return false.
     bool chain_orientation_of(const Snarl* snarl) const;
-        
+    
+    /// Get the rank that the given snarl appears in in its chain. If two
+    /// snarls are in forward orientation in the chain, then leaving the end of
+    /// the lower rank snarl will eventually reach the start of the higher rank
+    /// snarl. If either or both snarls is backward, you leave/arrive at the
+    /// other bounding node instead.
+    ///
+    /// Sorting snarls by rank will let you visit them in chain order without
+    /// walking the whole chain.
+    size_t chain_rank_of(const Snarl* snarl) const;
+    
     /// Return true if a Snarl is part of a nontrivial chain of more than one
     /// snarl. Note that chain_of() still works for snarls in trivial chains.
     bool in_nontrivial_chain(const Snarl* here) const;

--- a/src/stream/register_loader_saver_snarl_manager.cpp
+++ b/src/stream/register_loader_saver_snarl_manager.cpp
@@ -1,0 +1,57 @@
+/**
+ * \file register_loader_saver_snarl_manager.cpp
+ * Defines IO for a SnarlManager from stream files.
+ */
+
+#include "registry.hpp"
+#include "register_loader_saver_snarl_manager.hpp"
+
+#include "../snarls.hpp"
+
+namespace vg {
+
+namespace stream {
+
+using namespace std;
+
+void register_loader_saver_snarl_manager() {
+    Registry::register_loader_saver<SnarlManager>(vector<string>{"SNARL", ""}, [](const message_sender_function_t& for_each_message) -> void* {
+       SnarlManager* manager = new SnarlManager([&](const function<void(Snarl&)>& consume_snarl) {
+            // Call the source function with a function that deserializes each message and feeds it to the SnarlManager.
+            for_each_message([&](const string& serialized_snarl) {
+                // Parse the message to a Snarl
+                Snarl s;
+                if (!s.ParseFromString(serialized_snarl)) {
+                    // Handle bad graphs.
+                    // TODO: make this an exception if we ever want to be allowed to continue from this.
+                    cerr << "error[register_loader_saver_snarl_manager]: invalid Snarl message" << endl;
+                    exit(1);
+                }
+                
+                // Feed the Snarl to the SnarlManager.
+                // TODO: Is all this callback-and-callforth better than just a loop somewhere?
+                // TODO: Unify with the VG load logic to avoid duplicating deserialization
+                consume_snarl(s);
+            });
+        });
+        
+        return (void*) manager;
+    }, [](const void* manager_void, const message_consumer_function_t& send_message) {
+        // Cast to SnarlManager and serialize to the consumer.
+        assert(manager_void != nullptr);
+        
+        const SnarlManager* manager = (const SnarlManager*) manager_void;
+        
+        manager->for_each_snarl_preorder([&](const Snarl* snarl) {
+            // Serialize and emit each snarl
+            string s;
+            snarl->SerializeToString(&s);
+            send_message(s);
+        });
+    });
+}
+
+}
+
+}
+

--- a/src/stream/register_loader_saver_snarl_manager.hpp
+++ b/src/stream/register_loader_saver_snarl_manager.hpp
@@ -1,0 +1,16 @@
+/**
+ * \file register_loader_saver_snarl_manager.hpp
+ * Defines IO for a SnarlManager index from stream files.
+ */
+
+namespace vg {
+
+namespace stream {
+
+using namespace std;
+
+void register_loader_saver_snarl_manager();
+
+}
+
+}

--- a/src/stream/registry.cpp
+++ b/src/stream/registry.cpp
@@ -12,6 +12,7 @@
 #include "register_loader_saver_xg.hpp"
 #include "register_loader_saver_vg.hpp"
 #include "register_loader_saver_minimizer.hpp"
+#include "register_loader_saver_snarl_manager.hpp"
 
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/descriptor.h>
@@ -48,6 +49,7 @@ auto Registry::register_everything() -> bool {
     register_loader_saver_xg();
     register_loader_saver_vg();
     register_loader_saver_minimizer();
+    register_loader_saver_snarl_manager();
     
     return true;
 }

--- a/src/subcommand/cluster_main.cpp
+++ b/src/subcommand/cluster_main.cpp
@@ -1,0 +1,169 @@
+/**
+ * \file cluster_main.cpp: experimental snarl clustering test harness
+ */
+
+#include <omp.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include "subcommand.hpp"
+
+#include "../seed_clusterer.hpp"
+#include "../stream/vpkg.hpp"
+
+#include <iostream>
+
+using namespace std;
+using namespace vg;
+using namespace vg::subcommand;
+
+void help_cluster(char** argv) {
+    cerr
+    << "usage: " << argv[0] << " cluster [options] input.gam > output.gam" << endl
+    << "Find and cluster mapping seeds." << endl
+    << endl
+    << "basic options:" << endl
+    << "  -x, --xg-name FILE            use this xg index (required)" << endl
+    << "  -g, --gcsa-name FILE          use this GCSA2/LCP index pair (required; both FILE and FILE.lcp)" << endl
+    << "  -s, --snarls FILE             cluster using these snarls (required)" << endl
+    << "  -d, --dist-name FILE          cluster using this distance index (required)" << endl
+    << "computational parameters:" << endl
+    << "  -t, --threads INT             number of compute threads to use" << endl;
+}
+
+int main_cluster(int argc, char** argv) {
+
+    if (argc == 2) {
+        help_cluster(argv);
+        return 1;
+    }
+
+    // initialize parameters with their default options
+    string xg_name;
+    string gcsa_name;
+    string snarls_name;
+    string distance_name;
+    
+    int c;
+    optind = 2; // force optind past command positional argument
+    while (true) {
+        static struct option long_options[] =
+        {
+            {"help", no_argument, 0, 'h'},
+            {"xg-name", required_argument, 0, 'x'},
+            {"gcsa-name", required_argument, 0, 'g'},
+            {"snarls", required_argument, 0, 's'},
+            {"dist-name", required_argument, 0, 'd'},
+            {"threads", required_argument, 0, 't'},
+            {0, 0, 0, 0}
+        };
+
+        int option_index = 0;
+        c = getopt_long (argc, argv, "hx:g:s:d:t:",
+                         long_options, &option_index);
+
+
+        // Detect the end of the options.
+        if (c == -1)
+            break;
+
+        switch (c)
+        {
+            case 'x':
+                xg_name = optarg;
+                if (xg_name.empty()) {
+                    cerr << "error:[vg cluster] Must provide XG file with -x." << endl;
+                    exit(1);
+                }
+                break;
+                
+            case 'g':
+                gcsa_name = optarg;
+                if (gcsa_name.empty()) {
+                    cerr << "error:[vg cluster] Must provide GCSA file with -g." << endl;
+                    exit(1);
+                }
+                break;
+                
+            case 's':
+                snarls_name = optarg;
+                if (snarls_name.empty()) {
+                    cerr << "error:[vg cluster] Must provide snarl file with -s." << endl;
+                    exit(1);
+                }
+                break;
+                
+            case 'd':
+                distance_name = optarg;
+                if (snarls_name.empty()) {
+                    cerr << "error:[vg cluster] Must provide distance index file with -d." << endl;
+                    exit(1);
+                }
+                break;
+                
+            case 't':
+            {
+                int num_threads = parse<int>(optarg);
+                if (num_threads <= 0) {
+                    cerr << "error:[vg cluster] Thread count (-t) set to " << num_threads << ", must set to a positive integer." << endl;
+                    exit(1);
+                }
+                omp_set_num_threads(num_threads);
+            }
+                break;
+                
+            case 'h':
+            case '?':
+            default:
+                help_cluster(argv);
+                exit(1);
+                break;
+        }
+    }
+    
+    
+    if (xg_name.empty()) {
+        cerr << "error:[vg cluster] Finding clusters requires an XG index, must provide XG file (-x)" << endl;
+        exit(1);
+    }
+    
+    if (gcsa_name.empty()) {
+        cerr << "error:[vg cluster] Finding clusters requires a GCSA2 index, must provide GCSA2 file (-g)" << endl;
+        exit(1);
+    }
+    
+    if (snarls_name.empty()) {
+        cerr << "error:[vg cluster] Finding clusters requires snarls, must provide snarls file (-s)" << endl;
+        exit(1);
+    }
+    
+    if (distance_name.empty()) {
+        cerr << "error:[vg cluster] Finding clusters requires a distance index, must provide distance index file (-d)" << endl;
+        exit(1);
+    }
+    
+    // create in-memory objects
+    unique_ptr<xg::XG> xg_index = stream::VPKG::load_one<xg::XG>(xg_name);
+    unique_ptr<gcsa::GCSA> gcsa_index = stream::VPKG::load_one<gcsa::GCSA>(gcsa_name);
+    unique_ptr<gcsa::LCPArray> lcp_array = stream::VPKG::load_one<gcsa::LCPArray>(gcsa_name + ".lcp");
+    unique_ptr<SnarlManager> snarl_manager = stream::VPKG::load_one<SnarlManager>(snarls_name);
+    
+    // Now load the distance index.
+    unique_ptr<DistanceIndex> distance_index;
+    {
+        ifstream distance_stream(distance_name);
+        if (!distance_stream) {
+            cerr << "error:[vg cluster] Could not open " << distance_name << endl;
+            exit(1);
+        }
+        // TODO: let this go through VPKG as soon as we get it loadable without passing a graph
+        distance_index = make_unique<DistanceIndex>(xg_index.get(), snarl_manager.get(), distance_stream);
+    }
+   
+    return 0;
+}
+
+// Register subcommand
+static Subcommand vg_cluster("cluster", "find and cluster mapping seeds", DEVELOPMENT, main_cluster);
+
+

--- a/src/subcommand/cluster_main.cpp
+++ b/src/subcommand/cluster_main.cpp
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <vector>
 #include <unordered_set>
+#include <chrono>
 
 #include "subcommand.hpp"
 
@@ -197,9 +198,13 @@ int main_cluster(int argc, char** argv) {
                 }
             }
             
-            // Cluster the seeds. Get sets of input seed indexes that go together
+            // Cluster the seeds. Get sets of input seed indexes that go together.
+            // Make sure to time it.
+            std::chrono::time_point<std::chrono::system_clock> start = std::chrono::system_clock::now();
             vector<hash_set<size_t>> clusters = clusterer.cluster_seeds(seeds, distance_limit, *snarl_manager, *distance_index);
-            
+            std::chrono::time_point<std::chrono::system_clock> end = std::chrono::system_clock::now();
+            std::chrono::duration<double> elapsed_seconds = end-start;
+        
             // Put the biggest cluster first
             std::sort(clusters.begin(), clusters.end(), [](const hash_set<size_t>& a, const hash_set<size_t>& b) -> bool {
                 // Return true if a must come before b, and false otherwise
@@ -244,8 +249,10 @@ int main_cluster(int argc, char** argv) {
                 }
             }
             
-            // Tag the alignment
+            // Tag the alignment with cluster accuracy
             set_annotation(aln, "best_cluster_overlap", have_overlap);
+            // And with cluster time
+            set_annotation(aln, "cluster_seconds", elapsed_seconds.count());
             
 #ifdef debug
             cerr << "Overlap? " << have_overlap << endl;

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -900,8 +900,8 @@ int main_find(int argc, char** argv) {
                 Mapper mapper(xindex.get(), gcsa_index.get(), lcp_index.get());
                 mapper.fast_reseed = use_fast_reseed;
                 // get the mems
-                double lcp_max, fraction_filtered;
-                auto mems = mapper.find_mems_deep(sequence.begin(), sequence.end(), lcp_max, fraction_filtered, max_mem_length, min_mem_length, mem_reseed_length);
+                double lcp_avg, fraction_filtered;
+                auto mems = mapper.find_mems_deep(sequence.begin(), sequence.end(), lcp_avg, fraction_filtered, max_mem_length, min_mem_length, mem_reseed_length);
 
                 // dump them to stdout
                 cout << mems_to_json(mems) << endl;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -1,4 +1,4 @@
-    /**
+/**
  * \file mpmap_main.cpp: multipath mapping of reads to a graph
  */
 

--- a/src/unittest/seed_clusterer.cpp
+++ b/src/unittest/seed_clusterer.cpp
@@ -277,8 +277,10 @@ namespace unittest {
                                       seeds, lim, snarl_manager, dist_index); 
 
                 for (size_t a = 0; a < clusters.size(); a++) {
+                    // For each cluster
                     hash_set<size_t> clust = clusters[a];
                     for (size_t i1 : clust) {
+                        // For each clustered position
                         int64_t min_dist = -1;
                         for (size_t i2 : clust) {
                             pos_t pos1 = seeds[i1];
@@ -303,26 +305,40 @@ namespace unittest {
                         }
                         REQUIRE(min_dist <= lim);
                         for ( size_t b = 0; b < a ; b ++) {
+                            // For each other cluster
                             hash_set<size_t> clust2 = clusters[b];
                             for (size_t i2 : clust2) {
+                                // And each position in *that* cluster
                                 pos_t pos1 = seeds[i1];
                                 pos_t pos2 = seeds[i2];
-                            size_t len1 = graph.get_length(graph.get_handle(get_id(pos1), false));
-                            pos_t rev1 = make_pos_t(get_id(pos1), 
-                                                    !is_rev(pos1),
-                                                    len1 - get_offset(pos1)); 
-                            size_t len2 = graph.get_length(graph.get_handle(get_id(pos2), false));
-                            pos_t rev2 = make_pos_t(get_id(pos2), 
-                                                    !is_rev(pos2),
-                                                    len2 - get_offset(pos2)); 
-                            int64_t dist1 = dist_index.minDistance(pos1, pos2);
-                            int64_t dist2 = dist_index.minDistance(pos1, rev2);
-                            int64_t dist3 = dist_index.minDistance(rev1, pos2);
-                            int64_t dist4 = dist_index.minDistance(rev1, rev2);
-                            REQUIRE((    (dist1 == -1 || dist1 >= lim) 
-                                      && (dist2 == -1 ||  dist2 >= lim) 
-                                      && (dist3 == -1 ||  dist3 >= lim)  
-                                      && (dist4 == -1 || dist4 >= lim)));
+                                
+                                // Get reverse-complement versions of each position
+                                size_t len1 = graph.get_length(graph.get_handle(get_id(pos1), false));
+                                pos_t rev1 = make_pos_t(get_id(pos1), 
+                                                        !is_rev(pos1),
+                                                        len1 - get_offset(pos1)); 
+                                size_t len2 = graph.get_length(graph.get_handle(get_id(pos2), false));
+                                pos_t rev2 = make_pos_t(get_id(pos2), 
+                                                        !is_rev(pos2),
+                                                        len2 - get_offset(pos2)); 
+                                                        
+                                // Work out how far apart these positions in the two distinct clusters are
+                                int64_t dist1 = dist_index.minDistance(pos1, pos2);
+                                int64_t dist2 = dist_index.minDistance(pos1, rev2);
+                                int64_t dist3 = dist_index.minDistance(rev1, pos2);
+                                int64_t dist4 = dist_index.minDistance(rev1, rev2);
+                                if (dist1 != -1) {
+                                    REQUIRE(dist1 >= lim);
+                                }
+                                if (dist2 != -1) {
+                                    REQUIRE(dist2 >= lim);
+                                }
+                                if (dist3 != -1) {
+                                    REQUIRE(dist3 >= lim);
+                                }
+                                if (dist4 != -1) {
+                                    REQUIRE(dist4 >= lim);
+                                }
                             }
                         }
                     }

--- a/src/unittest/snarls.cpp
+++ b/src/unittest/snarls.cpp
@@ -3049,6 +3049,12 @@ namespace vg {
                 SECTION("The chain end orientations are correct") {
                     REQUIRE(start_backward(*chain) == false);
                     REQUIRE(end_backward(*chain) == true);
+                    REQUIRE(snarl_manager.chain_orientation_of(left_child) == false);
+                    REQUIRE(snarl_manager.chain_orientation_of(right_child) == true);
+                }
+                
+                SECTION("The chain ranks are correct") {
+                    REQUIRE(snarl_manager.chain_rank_of(left_child) < snarl_manager.chain_rank_of(right_child));
                 }
                     
                 SECTION("The chain ends are correct") {


### PR DESCRIPTION
I've sped up clustering from ~10s per read to ~3s per read by not walking the entire chain to keep track of which clusters have had their chains processed on . Apparently it's quite slow to build a giant hash table.

Unfortunately, this seems to break one of the unit tests. And there's still a big loop over all snarls in the chain in `get_clusters_chain` which we have to pull out somehow.