### PR TITLE
Use new libbdsg and fix build

### DIFF
--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1111,7 +1111,7 @@ int main_giraffe(int argc, char** argv) {
     auto gbz = vg::io::VPKG::load_one<gbwtgraph::GBZ>(registry.require("Giraffe GBZ").at(0));
 
     // Grab the distance index
-    auto distance_index;
+    SnarlDistanceIndex distance_index;
     distance_index.load(registry.require("Giraffe Distance Index").at(0));
 
     // Set up the mapper

--- a/src/unittest/minimizer_mapper.cpp
+++ b/src/unittest/minimizer_mapper.cpp
@@ -20,7 +20,7 @@ public:
     TestMinimizerMapper(
         gbwtgraph::GBWTGraph gbwt_graph,
         gbwtgraph::DefaultMinimizerIndex minimizer_index,
-        SnarlDistanceIndex distance_index,
+        SnarlDistanceIndex& distance_index,
         PathPositionHandleGraph* handle_graph) 
         : MinimizerMapper(gbwt_graph, minimizer_index, distance_index, handle_graph){};
     using MinimizerMapper::MinimizerMapper;


### PR DESCRIPTION
This fixes the build for me and uses a new libbdsg that seems to be able to load /public/groups/cgl/graph-genomes/xhchang/hgsvc_v2/HGSVC_hs38d1.dist.new and start printing it without an immediate out of bounds access.
